### PR TITLE
[core] Do not use System.Memory for NetStandard 2.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,6 @@
 
   <PropertyGroup>
     <Deterministic>true</Deterministic>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net472</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)\mono-nat.snk</AssemblyOriginatorKeyFile>
     <Out>out</Out>

--- a/Mono.Nat.Test/Main.cs
+++ b/Mono.Nat.Test/Main.cs
@@ -78,14 +78,14 @@ namespace Mono.Nat.Test {
 				/******************************************/
 
 				// Try to create a new port map:
-				var mapping = new Mapping(Protocol.Tcp, 6001, 6001);
+				var mapping = new Mapping(Protocol.Tcp, 6001, 6011);
 				await device.CreatePortMapAsync(mapping);
 				Console.WriteLine("Create Mapping: protocol={0}, public={1}, private={2}", mapping.Protocol, mapping.PublicPort,
 				                  mapping.PrivatePort);
 
 				// Try to retrieve confirmation on the port map we just created:
 				try {
-					Mapping m = await device.GetSpecificMappingAsync(Protocol.Tcp, 6001);
+					Mapping m = await device.GetSpecificMappingAsync(Protocol.Tcp, mapping.PublicPort);
 					Console.WriteLine("Specific Mapping: protocol={0}, public={1}, private={2}", m.Protocol, m.PublicPort,
 					                  m.PrivatePort);
 				} catch {

--- a/Mono.Nat.sln
+++ b/Mono.Nat.sln
@@ -1,9 +1,16 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mono.Nat", "Mono.Nat\Mono.Nat.csproj", "{86621E85-B2E0-4740-B2D9-C2B2793072DC}"
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30204.135
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mono.Nat", "Mono.Nat\Mono.Nat.csproj", "{86621E85-B2E0-4740-B2D9-C2B2793072DC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mono.Nat.Test", "Mono.Nat.Test\Mono.Nat.Test.csproj", "{8CE5A580-B988-4B93-86E6-D6A147AD5251}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mono.Nat.Test", "Mono.Nat.Test\Mono.Nat.Test.csproj", "{8CE5A580-B988-4B93-86E6-D6A147AD5251}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{79A6F778-5E92-459D-82C1-37D81512267B}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.Build.props = Directory.Build.props
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -22,6 +29,9 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {1D4DA68B-1431-4FC6-929D-012A272FB91F}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = Mono.Nat\Mono.Nat.csproj

--- a/Mono.Nat/BufferHelpers.cs
+++ b/Mono.Nat/BufferHelpers.cs
@@ -1,0 +1,52 @@
+﻿//
+// Authors:
+//   Ben Motmans <ben.motmans@gmail.com>
+//
+// Copyright (C) 2020 Alan McGovern
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+
+using System.Threading;
+
+namespace Mono.Nat
+{
+	static class BufferHelpers
+	{
+		const int Size = 8 * 1024;
+
+#if NETSTANDARD2_0
+		static byte[] CachedBuffer;
+
+		internal static byte[] Rent()
+			=> Interlocked.Exchange(ref CachedBuffer, null) ?? new byte[Size];
+
+		internal static byte[] Release(byte[] buffer)
+			=> Interlocked.Exchange(ref CachedBuffer, buffer);
+#else
+		internal static byte[] Rent()
+			=> System.Buffers.ArrayPool<byte>.Shared.Rent(Size);
+
+		internal static void Release(byte[] buffer)
+			=> System.Buffers.ArrayPool<byte>.Shared.Return(buffer);
+#endif
+	}
+}

--- a/Mono.Nat/Mono.Nat.csproj
+++ b/Mono.Nat/Mono.Nat.csproj
@@ -4,7 +4,6 @@
 	<Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
 	<PropertyGroup>
-		<Deterministic>true</Deterministic>
 		<GitThisAssembly>false</GitThisAssembly>
 		<TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
 
@@ -14,8 +13,12 @@
 		<BeforePack>$(BeforePack);SetPackProperties</BeforePack>
 	</PropertyGroup>
 
+	<PropertyGroup>
+		<DefineConstants Condition=" '$(TargetFramework)' == 'netstandard2.0'">$(DefineConstants);NETSTANDARD2_0</DefineConstants>
+		<DefineConstants Condition=" '$(TargetFramework)' == 'netstandard2.1'">$(DefineConstants);NETSTANDARD2_1</DefineConstants>
+	</PropertyGroup>
+
 	<ItemGroup>
-		<PackageReference Condition="'$(TargetFramework)' == 'netstandard2.0'" Include="System.Memory" Version="4.5.4" PrivateAssets="all" />
 		<PackageReference Include="GitInfo" Version="2.0.20" PrivateAssets="all" />
 	</ItemGroup>
 

--- a/Mono.Nat/Upnp/Searchers/UpnpSearcher.cs
+++ b/Mono.Nat/Upnp/Searchers/UpnpSearcher.cs
@@ -29,7 +29,6 @@
 //
 
 using System;
-using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -188,7 +187,7 @@ namespace Mono.Nat.Upnp
 			int abortCount = 0;
 			StringBuilder servicesXml = new StringBuilder ();
 			XmlDocument xmldoc = new XmlDocument ();
-			byte [] buffer = ArrayPool<byte>.Shared.Rent (10240);
+			byte[] buffer = BufferHelpers.Rent();
 			try {
 				while (true) {
 					var bytesRead = await s.ReadAsync (buffer, 0, buffer.Length);
@@ -209,7 +208,7 @@ namespace Mono.Nat.Upnp
 					}
 				}
 			} finally {
-				ArrayPool<byte>.Shared.Return (buffer);
+				BufferHelpers.Release(buffer);
 			}
 
 			NatUtility.Log ("{0}: Parsed services list", response.ResponseUri);

--- a/Mono.Nat/Upnp/UpnpNatDevice.cs
+++ b/Mono.Nat/Upnp/UpnpNatDevice.cs
@@ -27,7 +27,6 @@
 //
 
 using System;
-using System.Buffers;
 using System.IO;
 using System.Net;
 using System.Text;
@@ -36,7 +35,7 @@ using System.Collections.Generic;
 
 namespace Mono.Nat.Upnp
 {
-    sealed class UpnpNatDevice : NatDevice, IEquatable<UpnpNatDevice>
+	sealed class UpnpNatDevice : NatDevice, IEquatable<UpnpNatDevice>
 	{
 		/// <summary>
 		/// The url we can use to control the port forwarding
@@ -172,7 +171,7 @@ namespace Mono.Nat.Upnp
 		{
 			StringBuilder data = new StringBuilder ();
 			int bytesRead;
-			byte [] buffer = ArrayPool<byte>.Shared.Rent (10240);
+			byte [] buffer = BufferHelpers.Rent ();
 			try {
 				// Read out the content of the message, hopefully picking everything up in the case where we have no contentlength
 				if (length != -1) {
@@ -186,7 +185,7 @@ namespace Mono.Nat.Upnp
 						data.Append (Encoding.UTF8.GetString (buffer, 0, bytesRead));
 				}
 			} finally {
-				ArrayPool<byte>.Shared.Return (buffer);
+				BufferHelpers.Release (buffer);
 			}
 
 			// Once we have our content, we need to see what kind of message it is. If we received


### PR DESCRIPTION
We can write big-endian numbers in all platforms
with a 1-liner (more or less).

The ArrayPool can be implemented in a simple way
for .NET Standard 2.0 (cache 1 array), and for
all newer iterations of .NET Standard we can
depend on ArrayPool.