### PR TITLE
[core] Issue SSDP requests for 'all' and for specific URNS

### DIFF
--- a/Mono.Nat/Upnp/Messages/DiscoverDeviceMessage.cs
+++ b/Mono.Nat/Upnp/Messages/DiscoverDeviceMessage.cs
@@ -31,7 +31,13 @@ namespace Mono.Nat.Upnp
 {
 	static class DiscoverDeviceMessage
 	{
-		internal static readonly string[] SupportedServiceTypes = new [] {
+		internal static readonly string[] SupportedServiceTypes = new[] {
+			"urn:schemas-upnp-org:device:InternetGatewayDevice:1",
+			"urn:schemas-upnp-org:device:InternetGatewayDevice:2",
+			"urn:schemas-upnp-org:device:InternetGatewayDevice:",
+		};
+
+		static readonly string[] SearchServiceTypes = new [] {
 			"all",
 			"urn:schemas-upnp-org:device:InternetGatewayDevice:1",
 			"urn:schemas-upnp-org:device:InternetGatewayDevice:2",
@@ -43,13 +49,13 @@ namespace Mono.Nat.Upnp
 		/// <returns></returns>
 		public static byte [][] EncodeSSDP ()
 		{
-			var results = new byte[SupportedServiceTypes.Length][];
-			for (int i = 0; i < SupportedServiceTypes.Length; i++) {
+			var results = new byte[SearchServiceTypes.Length][];
+			for (int i = 0; i < SearchServiceTypes.Length; i++) {
 				var s = "M-SEARCH * HTTP/1.1\r\n"
 						+ "HOST: 239.255.255.250:1900\r\n"
 						+ "MAN: \"ssdp:discover\"\r\n"
 						+ "MX: 3\r\n"
-						+ string.Format("ST: ssdp:{0}\r\n\r\n", SupportedServiceTypes[i]);
+						+ string.Format("ST: ssdp:{0}\r\n\r\n", SearchServiceTypes[i]);
 				results[i] = Encoding.ASCII.GetBytes(s);
 			}
 			return results;
@@ -59,13 +65,13 @@ namespace Mono.Nat.Upnp
 		{
 			//Format obtained from http://upnp.org/specs/arch/UPnP-arch-DeviceArchitecture-v1.1.pdf pg 31
 			//This method only works with upnp 1.1 routers... unfortunately
-			var results = new byte[SupportedServiceTypes.Length][];
-			for (int i = 0; i < SupportedServiceTypes.Length; i++)
+			var results = new byte[SearchServiceTypes.Length][];
+			for (int i = 0; i < SearchServiceTypes.Length; i++)
 			{
 				string s = "M-SEARCH * HTTP/1.1\r\n"
 						+ "HOST: " + gatewayAddress + ":1900\r\n"
 						+ "MAN: \"ssdp:discover\"\r\n"
-						+ string.Format("ST: ssdp:{0}\r\n\r\n", SupportedServiceTypes[i]);
+						+ string.Format("ST: ssdp:{0}\r\n\r\n", SearchServiceTypes[i]);
 				results[i] = Encoding.ASCII.GetBytes(s);
 			}
 			return results;

--- a/Mono.Nat/Upnp/Messages/DiscoverDeviceMessage.cs
+++ b/Mono.Nat/Upnp/Messages/DiscoverDeviceMessage.cs
@@ -31,30 +31,44 @@ namespace Mono.Nat.Upnp
 {
 	static class DiscoverDeviceMessage
 	{
+		internal static readonly string[] SupportedServiceTypes = new [] {
+			"all",
+			"urn:schemas-upnp-org:device:InternetGatewayDevice:1",
+			"urn:schemas-upnp-org:device:InternetGatewayDevice:2",
+		};
+
 		/// <summary>
 		/// The message sent to discover all uPnP devices on the network
 		/// </summary>
 		/// <returns></returns>
-		public static byte [] EncodeSSDP ()
+		public static byte [][] EncodeSSDP ()
 		{
-			string s = "M-SEARCH * HTTP/1.1\r\n"
+			var results = new byte[SupportedServiceTypes.Length][];
+			for (int i = 0; i < SupportedServiceTypes.Length; i++) {
+				var s = "M-SEARCH * HTTP/1.1\r\n"
 						+ "HOST: 239.255.255.250:1900\r\n"
 						+ "MAN: \"ssdp:discover\"\r\n"
 						+ "MX: 3\r\n"
-						+ "ST: ssdp:all\r\n\r\n";
-			return Encoding.ASCII.GetBytes (s);
+						+ string.Format("ST: ssdp:{0}\r\n\r\n", SupportedServiceTypes[i]);
+				results[i] = Encoding.ASCII.GetBytes(s);
+			}
+			return results;
 		}
 
-		public static byte [] EncodeUnicast (IPAddress gatewayAddress)
+		public static byte [][] EncodeUnicast (IPAddress gatewayAddress)
 		{
 			//Format obtained from http://upnp.org/specs/arch/UPnP-arch-DeviceArchitecture-v1.1.pdf pg 31
 			//This method only works with upnp 1.1 routers... unfortunately
-			string s = "M-SEARCH * HTTP/1.1\r\n"
+			var results = new byte[SupportedServiceTypes.Length][];
+			for (int i = 0; i < SupportedServiceTypes.Length; i++)
+			{
+				string s = "M-SEARCH * HTTP/1.1\r\n"
 						+ "HOST: " + gatewayAddress + ":1900\r\n"
 						+ "MAN: \"ssdp:discover\"\r\n"
-						+ "ST: ssdp:all\r\n\r\n";
-			//+ "USER-AGENT: unix/5.1 UPnP/1.1 MyProduct/1.0\r\n\r\n";
-			return Encoding.ASCII.GetBytes (s);
+						+ string.Format("ST: ssdp:{0}\r\n\r\n", SupportedServiceTypes[i]);
+				results[i] = Encoding.ASCII.GetBytes(s);
+			}
+			return results;
 		}
 	}
 }


### PR DESCRIPTION
Some routers respond to 'all' request and list their
WANPPPConnection or WANIPConnection services, some do
not.

For the ones which do not, querying for
InternetGatewayDevice and accepting that as a valid
possibility should be sufficient to allow Mono.Nat
to fetch the service list and get confirmation
that WANIP or WANPPP is supported.

Fixes https://github.com/alanmcgovern/Mono.Nat/issues/17