### PR TITLE
Implemented DeviceUnknown event

### DIFF
--- a/Mono.Nat/EventArgs/DeviceEventUnknownArgs.cs
+++ b/Mono.Nat/EventArgs/DeviceEventUnknownArgs.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Net;
+
+namespace Mono.Nat
+{
+    public class DeviceEventUnknownArgs : EventArgs
+    {
+        public IPAddress Address { get; }
+
+        public string Data { get; }
+
+        public EndPoint EndPoint { get; }
+
+        public DeviceEventUnknownArgs(IPAddress address, EndPoint endPoint, string data)
+        {
+            Address = address;
+            Data = data;
+            EndPoint = endPoint;
+        }
+    }
+}

--- a/Mono.Nat/ISearcher.cs
+++ b/Mono.Nat/ISearcher.cs
@@ -30,6 +30,7 @@
 
 using System;
 using System.Net;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -74,5 +75,14 @@ namespace Mono.Nat
 		/// The searcher will no longer listen for new devices.
 		/// </summary>
 		void Stop ();
-	}
+
+        /// <summary>
+        /// Permits Mono.NAT to process messages not received internally.
+        /// </summary>
+        /// <param name="localAddress">Interface ip.</param>
+        /// <param name="response">Response received.</param>
+        /// <param name="endpoint">Destination ip.</param>
+        /// <pamam name="token">Cancellation token.</pamam>
+        void HandleMessageReceived(IPAddress localAddress, byte[] response, IPEndPoint endpoint, CancellationToken token);
+    }
 }

--- a/Mono.Nat/ISearcher.cs
+++ b/Mono.Nat/ISearcher.cs
@@ -37,15 +37,20 @@ namespace Mono.Nat
 {
 	interface ISearcher : IDisposable
 	{
-		/// <summary>
-		/// This event is raised whenever a device which supports port mapping is discovered
-		/// </summary>
-		event EventHandler<DeviceEventArgs> DeviceFound;
+        /// <summary>
+        /// This event is raised whenever a device which supports port mapping is discovered
+        /// </summary>
+        event EventHandler<DeviceEventArgs> DeviceFound;
 
-		/// <summary>
-		/// The port mapping protocol supported by the device
-		/// </summary>
-		NatProtocol Protocol { get; }
+        /// <summary>
+        /// This event is raised whenever a device which doesn't supports port mapping is discovered.
+        /// </summary>
+        event EventHandler<DeviceEventUnknownArgs> DeviceUnknown;
+
+        /// <summary>
+        /// The port mapping protocol supported by the device
+        /// </summary>
+        NatProtocol Protocol { get; }
 
 		/// <summary>
 		/// While running the searcher constantly listens for UDP broadcasts when new devices come online.

--- a/Mono.Nat/ISearcher.cs
+++ b/Mono.Nat/ISearcher.cs
@@ -82,7 +82,7 @@ namespace Mono.Nat
         /// <param name="localAddress">Interface ip.</param>
         /// <param name="response">Response received.</param>
         /// <param name="endpoint">Destination ip.</param>
-        /// <pamam name="token">Cancellation token.</pamam>
+        /// <param name="token">Cancellation token.</pamam>
         Task HandleMessageReceived(IPAddress localAddress, byte[] response, IPEndPoint endpoint, CancellationToken token);
     }
 }

--- a/Mono.Nat/ISearcher.cs
+++ b/Mono.Nat/ISearcher.cs
@@ -83,6 +83,6 @@ namespace Mono.Nat
         /// <param name="response">Response received.</param>
         /// <param name="endpoint">Destination ip.</param>
         /// <pamam name="token">Cancellation token.</pamam>
-        void HandleMessageReceived(IPAddress localAddress, byte[] response, IPEndPoint endpoint, CancellationToken token);
+        Task HandleMessageReceived(IPAddress localAddress, byte[] response, IPEndPoint endpoint, CancellationToken token);
     }
 }

--- a/Mono.Nat/ISearcher.cs
+++ b/Mono.Nat/ISearcher.cs
@@ -82,7 +82,7 @@ namespace Mono.Nat
         /// <param name="localAddress">Interface ip.</param>
         /// <param name="response">Response received.</param>
         /// <param name="endpoint">Destination ip.</param>
-        /// <param name="token">Cancellation token.</pamam>
+        /// <param name="token">Cancellation token.</param>
         Task HandleMessageReceived(IPAddress localAddress, byte[] response, IPEndPoint endpoint, CancellationToken token);
     }
 }

--- a/Mono.Nat/Pmp/Searchers/PmpSearcher.cs
+++ b/Mono.Nat/Pmp/Searchers/PmpSearcher.cs
@@ -127,7 +127,13 @@ namespace Mono.Nat.Pmp
 
 		protected override async Task SearchAsync (IPAddress gatewayAddress, TimeSpan? repeatInterval, CancellationToken token)
 		{
-			do {
+            if (token == CancellationToken.None)
+            {
+                token = Cancellation.Token;
+            }
+
+            do
+            {
 				var currentSearch = CancellationTokenSource.CreateLinkedTokenSource (token);
 				Interlocked.Exchange (ref CurrentSearchCancellation, currentSearch)?.Cancel ();
 
@@ -154,11 +160,8 @@ namespace Mono.Nat.Pmp
 			}
 		}
 
-		protected override Task HandleMessageReceived (IPAddress localAddress, UdpReceiveResult result, CancellationToken token)
-		{
-			var response = result.Buffer;
-			var endpoint = result.RemoteEndPoint;
-
+        public override Task HandleMessageReceived(IPAddress localAddress, byte[] response, IPEndPoint endpoint, CancellationToken token)
+        { 
 			if (response.Length != 12)
 				return Task.CompletedTask;
 			if (response [0] != PmpConstants.Version)

--- a/Mono.Nat/Searcher.cs
+++ b/Mono.Nat/Searcher.cs
@@ -47,7 +47,7 @@ namespace Mono.Nat
 		Task ListeningTask { get; set; }
 		protected SocketGroup Clients { get; }
 
-		CancellationTokenSource Cancellation;
+		protected CancellationTokenSource Cancellation;
 		protected CancellationTokenSource CurrentSearchCancellation;
 		CancellationTokenSource OverallSearchCancellation;
 		Task SearchTask { get; set; }
@@ -79,13 +79,13 @@ namespace Mono.Nat
 		{
 			while (!token.IsCancellationRequested) {
 				(var localAddress, var data) = await Clients.ReceiveAsync (token).ConfigureAwait (false);
-				await HandleMessageReceived (localAddress, data, token).ConfigureAwait (false);
+				await HandleMessageReceived (localAddress, data.Buffer, data.RemoteEndPoint, token).ConfigureAwait (false);
 			}
 		}
 
-		protected abstract Task HandleMessageReceived (IPAddress localAddress, UdpReceiveResult result, CancellationToken token);
+        public abstract Task HandleMessageReceived(IPAddress localAddress, byte[] response, IPEndPoint endpoint, CancellationToken token);
 
-		public async Task SearchAsync ()
+        public async Task SearchAsync ()
 		{
 			// Cancel any existing continuous search operation.
 			OverallSearchCancellation?.Cancel ();

--- a/Mono.Nat/Searcher.cs
+++ b/Mono.Nat/Searcher.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Authors:
 //   Alan McGovern alan.mcgovern@gmail.com
 //
@@ -38,6 +38,7 @@ namespace Mono.Nat
 		protected static readonly TimeSpan SearchPeriod = TimeSpan.FromMinutes (5);
 
 		public event EventHandler<DeviceEventArgs> DeviceFound;
+        public event EventHandler<DeviceEventUnknownArgs> DeviceUnknown;
 
 		public bool Listening => ListeningTask != null;
 		public abstract NatProtocol Protocol { get; }
@@ -121,6 +122,11 @@ namespace Mono.Nat
 			SearchTask = null;
 		}
 
+        protected void RaiseDeviceUnknown(IPAddress address, EndPoint remote, string response)
+        {
+            DeviceUnknown?.Invoke(this, new DeviceEventUnknownArgs(address, remote, response));
+        }
+
 		protected void RaiseDeviceFound (NatDevice device)
 		{
 			CurrentSearchCancellation?.Cancel ();
@@ -135,7 +141,7 @@ namespace Mono.Nat
 			// If we did not find the device in the dictionary, raise an event as it's the first time
 			// we've encountered it!
 			if (actualDevice == null)
-				DeviceFound?.Invoke (this, new DeviceEventArgs (device));
-		}
+                DeviceFound?.Invoke(this, new DeviceEventArgs(device));
+        }
 	}
 }

--- a/Mono.Nat/SocketGroup.cs
+++ b/Mono.Nat/SocketGroup.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
@@ -45,7 +45,7 @@ namespace Mono.Nat
 				await Task.Delay (10, token);
 			}
 
-			throw new Exception ("Should not be reached");
+            throw new TaskCanceledException();
 		}
 
 		public async Task SendAsync (byte [] buffer, IPAddress gatewayAddress, CancellationToken token)

--- a/Mono.Nat/SocketGroup.cs
+++ b/Mono.Nat/SocketGroup.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace Mono.Nat
 {
-	class SocketGroup : IDisposable
+	public class SocketGroup : IDisposable
 	{
 		Dictionary<UdpClient, List<IPAddress>> Sockets { get; }
 		SemaphoreSlim SocketSendLocker { get; }

--- a/Mono.Nat/Upnp/Searchers/UpnpSearcher.cs
+++ b/Mono.Nat/Upnp/Searchers/UpnpSearcher.cs
@@ -74,20 +74,34 @@ namespace Mono.Nat.Upnp
 					{
 						if (address.Address.AddressFamily == AddressFamily.InterNetwork)
 						{
-							try
-							{
-								var client = new UdpClient(new IPEndPoint(address.Address, 0));
-								clients.Add(client, gateways);
-							}
-							catch
-							{
-								continue; // Move on to the next address.
-							}
-						}
-					}
-				}
-			}
-			catch (Exception)
+                            try
+                            {
+                                var client = new UdpClient(new IPEndPoint(address.Address, 0));
+                                clients.Add(client, gateways);
+                            }
+                            catch (Exception ex)
+                            {
+                                Log.Error(ex.Message);
+                                continue; // Move on to the next address.
+                            }
+                        }
+                    }
+                }
+
+                // This enables NOTIFY messages to be received when M$ SSDPSRV service is running under Windows.
+                try
+                {
+                    var listener = new UdpClient(new IPEndPoint(IPAddress.Any, 1900));
+                   listener.Client.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership, new MulticastOption(gateways[0], IPAddress.Any));
+                    clients.Add(listener, gateways);
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex.Message + "\r\nMono.NAT will be unable to listen on windows systems if cmd is running.");
+                }
+
+            }
+            catch (Exception)
 			{
 				clients.Add(new UdpClient(0), gateways);
 			}

--- a/Mono.Nat/Upnp/Searchers/UpnpSearcher.cs
+++ b/Mono.Nat/Upnp/Searchers/UpnpSearcher.cs
@@ -127,15 +127,19 @@ namespace Mono.Nat.Upnp
 			} while (true);
 		}
 
-		protected override async Task HandleMessageReceived (IPAddress localAddress, UdpReceiveResult result, CancellationToken token)
-		{
-			// Convert it to a string for easy parsing
-			string dataString = null;
-			var response = result.Buffer;
+        public override async Task HandleMessageReceived(IPAddress localAddress, byte[] response, IPEndPoint remoteEndPoint, CancellationToken token)
+        {
+            if (token == CancellationToken.None)
+            {
+                token = Cancellation.Token;
+            }
+
+            string dataString = null;
 
             // No matter what, this method should never throw an exception. If something goes wrong
             // we should still be in a position to handle the next reply correctly.
-            try {
+            try
+            {
                 dataString = Encoding.UTF8.GetString (response);
 
                 Log.InfoFormatted ("uPnP Search Response: {0}", dataString);
@@ -157,7 +161,7 @@ namespace Mono.Nat.Upnp
                 }
 
                 if (foundService == null) {
-                    RaiseDeviceUnknown(localAddress, result.RemoteEndPoint, dataString, NatProtocol.Upnp);
+                    RaiseDeviceUnknown(localAddress, remoteEndPoint, dataString, NatProtocol.Upnp);
                     return;
                 }
                     


### PR DESCRIPTION
Helps solves an issue whereby two processes listening on the same interface/port interact randomly.

e., Jellyfin implements a DLNA server on the same interfaces/ports so was randomly picking up Mono.NAT's broadcast replies and loosing its own.

By implementing a device unknown - it has been possible to turn the sockets with gateways into send only, thus ensuring Mono works as designed. 

By implementing this event for any comms that arrive on mono's sockets, it's possible to feed them back through into Jellyfin's processing routines and for the two to exist in harmony.
