### PR TITLE
Possible processing loop removal

### DIFF
--- a/Mono.Nat/Upnp/Searchers/UpnpSearcher.cs
+++ b/Mono.Nat/Upnp/Searchers/UpnpSearcher.cs
@@ -149,6 +149,8 @@ namespace Mono.Nat.Upnp
                     RaiseDeviceUnknown (localAddress, remoteEndPoint, dataString, NatProtocol.Upnp);
                     return;
                 }
+                else if (foundService == null)
+                    return;
 
                 if (token == CancellationToken.None) {
                     token = Cancellation.Token;

--- a/Mono.Nat/Upnp/Searchers/UpnpSearcher.cs
+++ b/Mono.Nat/Upnp/Searchers/UpnpSearcher.cs
@@ -120,10 +120,6 @@ namespace Mono.Nat.Upnp
 
         public override async Task HandleMessageReceived (IPAddress localAddress, byte[] response, IPEndPoint remoteEndPoint, CancellationToken token)
         {
-            if (token == CancellationToken.None) {
-                token = Cancellation.Token;
-            }
-
             string dataString = null;
 
             // No matter what, this method should never throw an exception. If something goes wrong
@@ -149,9 +145,13 @@ namespace Mono.Nat.Upnp
                     }
                 }
 
-                if (foundService == null) {
+                if (foundService == null && token != CancellationToken.None) {
                     RaiseDeviceUnknown (localAddress, remoteEndPoint, dataString, NatProtocol.Upnp);
                     return;
+                }
+
+                if (token == CancellationToken.None) {
+                    token = Cancellation.Token;
                 }
 
                 Log.InfoFormatted ("uPnP Search Response: Router advertised a '{0}' service", foundService);


### PR DESCRIPTION
By moving the token re-assignment until after the event call, and adding the check onto the RaiseDeviceUnknown, the possibility of a loop whereby unit1 sends unknown message to Mono.NAT which sends it back to unit1 is removed.