### PR TITLE
Simplify cancellation

### DIFF
--- a/Mono.Nat/AsyncExtensions.cs
+++ b/Mono.Nat/AsyncExtensions.cs
@@ -31,16 +31,5 @@ namespace Mono.Nat
             await semaphore.WaitAsync (token);
             return new SemaphoreSlimDisposable (semaphore);
         }
-
-        public static async void FireAndForget (this Task task)
-        {
-            try {
-                await task.ConfigureAwait (false);
-            } catch (OperationCanceledException) {
-                // If we cancel the task then we don't need to log anything.
-            } catch (Exception ex) {
-                Log.ErrorFormatted ("Unhandled exception: {0}{1}", Environment.NewLine, ex);
-            }
-        }
     }
 }

--- a/Mono.Nat/ISearcher.cs
+++ b/Mono.Nat/ISearcher.cs
@@ -62,19 +62,14 @@ namespace Mono.Nat
         /// Periodically send a multicast UDP message to scan for new devices.
         /// If the searcher is not listening, it will begin listening until 'Stop' is invoked.
         /// </summary>
-        Task SearchAsync ();
+        void SearchAsync ();
 
         /// <summary>
         /// Immediately sends a unicast UDP message to this IP address to check for a compatible device.
         /// If the searcher is not listening, it will begin listening until 'Stop' is invoked.
         /// </summary>
         /// <param name="gatewayAddress">The IP address which should</param>
-        Task SearchAsync (IPAddress gatewayAddress);
-
-        /// <summary>
-        /// The searcher will no longer listen for new devices.
-        /// </summary>
-        Task StopAsync ();
+        void SearchAsync (IPAddress gatewayAddress);
 
         /// <summary>
         /// Permits Mono.NAT to process messages not received internally.

--- a/Mono.Nat/ISearcher.cs
+++ b/Mono.Nat/ISearcher.cs
@@ -62,14 +62,14 @@ namespace Mono.Nat
         /// Periodically send a multicast UDP message to scan for new devices.
         /// If the searcher is not listening, it will begin listening until 'Stop' is invoked.
         /// </summary>
-        void SearchAsync ();
+        void BeginSearching ();
 
         /// <summary>
         /// Immediately sends a unicast UDP message to this IP address to check for a compatible device.
         /// If the searcher is not listening, it will begin listening until 'Stop' is invoked.
         /// </summary>
         /// <param name="gatewayAddress">The IP address which should</param>
-        void SearchAsync (IPAddress gatewayAddress);
+        void BeginSearching (IPAddress gatewayAddress);
 
         /// <summary>
         /// Permits Mono.NAT to process messages not received internally.

--- a/Mono.Nat/Mono.Nat.csproj
+++ b/Mono.Nat/Mono.Nat.csproj
@@ -33,6 +33,10 @@
 		<CoreCompileDependsOn>SetBuildVersion;$(CoreCompileDependsOn)</CoreCompileDependsOn>
 	</PropertyGroup>
 
+	<PropertyGroup>
+	  <NoWarn>1701;1702;1591</NoWarn>
+	</PropertyGroup>
+
 	<Target Name="SetBuildVersion" DependsOnTargets="GitInfo">
 		<PropertyGroup>
 			<SourceRevisionId>$(GitSha)</SourceRevisionId>

--- a/Mono.Nat/NatUtility.cs
+++ b/Mono.Nat/NatUtility.cs
@@ -75,7 +75,7 @@ namespace Mono.Nat
         public static void Search (IPAddress gatewayAddress, NatProtocol type)
         {
             lock (Locker)
-                GetOrCreate (type).SearchAsync (gatewayAddress);
+                GetOrCreate (type).BeginSearching (gatewayAddress);
         }
 
         static void HandleDeviceFound (object sender, DeviceEventArgs e)
@@ -98,7 +98,7 @@ namespace Mono.Nat
             lock (Locker) {
                 devices = devices.Length == 0 ? AllProtocols : devices;
                 foreach (var protocol in devices)
-                    GetOrCreate (protocol).SearchAsync ();
+                    GetOrCreate (protocol).BeginSearching ();
             }
         }
 

--- a/Mono.Nat/NatUtility.cs
+++ b/Mono.Nat/NatUtility.cs
@@ -75,7 +75,7 @@ namespace Mono.Nat
         public static void Search (IPAddress gatewayAddress, NatProtocol type)
         {
             lock (Locker)
-                GetOrCreate (type).SearchAsync (gatewayAddress).FireAndForget ();
+                GetOrCreate (type).SearchAsync (gatewayAddress);
         }
 
         static void HandleDeviceFound (object sender, DeviceEventArgs e)
@@ -98,7 +98,7 @@ namespace Mono.Nat
             lock (Locker) {
                 devices = devices.Length == 0 ? AllProtocols : devices;
                 foreach (var protocol in devices)
-                    GetOrCreate (protocol).SearchAsync ().FireAndForget ();
+                    GetOrCreate (protocol).SearchAsync ();
             }
         }
 
@@ -121,10 +121,8 @@ namespace Mono.Nat
         public static void StopDiscovery ()
         {
             lock (Locker) {
-                foreach (var searcher in Searchers.Values) {
-                    searcher.StopAsync ().FireAndForget ();
+                foreach (var searcher in Searchers.Values)
                     searcher.Dispose ();
-                }
                 Searchers.Clear ();
             }
         }

--- a/Mono.Nat/Pmp/Searchers/PmpSearcher.cs
+++ b/Mono.Nat/Pmp/Searchers/PmpSearcher.cs
@@ -112,10 +112,6 @@ namespace Mono.Nat.Pmp
 
         protected override async void SearchAsync (IPAddress gatewayAddress, TimeSpan? repeatInterval, CancellationToken token)
         {
-            if (token == CancellationToken.None) {
-                token = Cancellation.Token;
-            }
-
             do {
                 CurrentSearchCancellation?.Cancel ();
                 var currentSearch = CurrentSearchCancellation = CancellationTokenSource.CreateLinkedTokenSource (token);

--- a/Mono.Nat/Pmp/Searchers/PmpSearcher.cs
+++ b/Mono.Nat/Pmp/Searchers/PmpSearcher.cs
@@ -102,6 +102,7 @@ namespace Mono.Nat.Pmp
         }
 
         CancellationTokenSource CurrentSearchCancellation { get; set; }
+
         public override NatProtocol Protocol => NatProtocol.Pmp;
 
         PmpSearcher (SocketGroup sockets)

--- a/Mono.Nat/Pmp/Searchers/PmpSearcher.cs
+++ b/Mono.Nat/Pmp/Searchers/PmpSearcher.cs
@@ -133,7 +133,7 @@ namespace Mono.Nat.Pmp
                     break;
                 }
 
-            } while (true);
+            } while (!token.IsCancellationRequested);
         }
 
         async Task SearchOnce (IPAddress gatewayAddress, CancellationToken token)

--- a/Mono.Nat/Searcher.cs
+++ b/Mono.Nat/Searcher.cs
@@ -63,8 +63,8 @@ namespace Mono.Nat
         {
             // Begin listening, if we are not already listening.
             if (!Listening) {
-                ListenAsync (Cancellation.Token);
                 Listening = true;
+                ListenAsync (Cancellation.Token);
             }
         }
 
@@ -79,8 +79,11 @@ namespace Mono.Nat
             while (!token.IsCancellationRequested) {
                 try {
                     (var localAddress, var data) = await Clients.ReceiveAsync (token).ConfigureAwait (false);
+
+                    token.ThrowIfCancellationRequested ();
                     await HandleMessageReceived (localAddress, data.Buffer, data.RemoteEndPoint, false, token).ConfigureAwait (false);
                 } catch (OperationCanceledException) {
+                    Listening = false;
                     return;
                 } catch(Exception ex) {
                     Log.ExceptionFormated (ex, "Unhandled exception listening for clients in {0}", GetType().Name);

--- a/Mono.Nat/Searcher.cs
+++ b/Mono.Nat/Searcher.cs
@@ -96,14 +96,14 @@ namespace Mono.Nat
 
         protected abstract Task HandleMessageReceived (IPAddress localAddress, byte[] response, IPEndPoint endpoint, bool externalEvent, CancellationToken token);
 
-        public void SearchAsync ()
+        public void BeginSearching ()
         {
             // Create a CancellationTokenSource for the search we're about to perform.
             BeginListening ();
             SearchAsync (null, SearchPeriod, Cancellation.Token);
         }
 
-        public void SearchAsync (IPAddress gatewayAddress)
+        public void BeginSearching (IPAddress gatewayAddress)
         {
             BeginListening ();
             SearchAsync (gatewayAddress, null, Cancellation.Token);

--- a/Mono.Nat/Upnp/Searchers/UpnpSearcher.cs
+++ b/Mono.Nat/Upnp/Searchers/UpnpSearcher.cs
@@ -105,7 +105,7 @@ namespace Mono.Nat.Upnp
             Locker = new SemaphoreSlim (1, 1);
         }
 
-        protected override async Task SearchAsync (IPAddress gatewayAddress, TimeSpan? repeatInterval, CancellationToken token)
+        protected override async void SearchAsync (IPAddress gatewayAddress, TimeSpan? repeatInterval, CancellationToken token)
         {
             var messages = gatewayAddress == null ? DiscoverDeviceMessage.EncodeSSDP () : DiscoverDeviceMessage.EncodeUnicast (gatewayAddress);
 


### PR DESCRIPTION
This allows us to do cancellation synchronously (in a threadsafe way), and so we can remove a fair chunk of complexity from this codepath.